### PR TITLE
Fix build with OCaml 4.07 (#5)

### DIFF
--- a/caml2html_test.ml
+++ b/caml2html_test.ml
@@ -32,7 +32,7 @@ type t = [ `A | `b of int | ` C | ` (* *) D | `
 
 (*foo*)
 
-module Zéro'04 =
+module Zero'04 =
 struct
   let characters = [ 'a'; '\000'; '\x12'; '
 '; '\t'; 'z' ]
@@ -63,4 +63,5 @@ let b x = a (a x)
 let _ = fun x -> b (b x)
 ;;
 
-# 123 (* line directives are not parsed, sorry... *)
+#123 "file.ml"  (* line directives are not parsed, sorry... *)
+


### PR DESCRIPTION

And this works on 4.07:

```
opam pin add caml2html "https://github.com/smondet/caml2html.git#fix-build-407-issue-5"
```